### PR TITLE
Support for Kindle Fire and discrimination between iPad/iPhone

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Parsing user agent strings is a hell. There is no standard for user agent string
   * https://developer.chrome.com/multidevice/user-agent
   * https://developer.apple.com/library/safari/documentation/AppleApplications/Reference/SafariWebContent/OptimizingforSafarioniPhone/OptimizingforSafarioniPhone.html#//apple_ref/doc/uid/TP40006517-SW3
   * http://blogs.msdn.com/b/ieinternals/archive/2013/09/21/internet-explorer-11-user-agent-string-ua-string-sniffing-compatibility-with-gecko-webkit.aspx
+  * http://docs.aws.amazon.com/silk/latest/developerguide/user-agent.html
 
 for the supported user agents see:
   * browsers: [browser.go](browser.go)

--- a/browser.go
+++ b/browser.go
@@ -27,6 +27,7 @@ var browsers = map[string]*url.URL{
 	"IceCat":    u("https://www.gnu.org/software/gnuzilla/"),
 	"Iceweasel": u("https://wiki.debian.org/Iceweasel"),
 	"NetSurf":   u("http://www.netsurf-browser.org/"),
+	"Silk":      u("http://aws.amazon.com/documentation/silk/"),
 }
 
 func parseBrowser(l *lex) *UserAgent {
@@ -172,6 +173,14 @@ func parseChromeSafari(l *lex) *UserAgent {
 			return nil
 		}
 		ua.Name = "Safari"
+	} else if ua.Name == "Silk" {
+		if l.match("like Chrome/") {
+			if _, ok := l.span(" "); !ok {
+				return nil
+			}
+		} else {
+			return nil
+		}
 	}
 	if ua.OS == "Android" {
 		if l.match("Mobile") {

--- a/browser.go
+++ b/browser.go
@@ -108,7 +108,11 @@ func parseMozillaLike(l *lex, ua *UserAgent) bool {
 		ua.Security = parseSecurity(l)
 		ua.OS = "Firefox OS"
 		ua.Tablet = true
-	case l.match("iPhone; ") || l.match("iPod; ") || l.match("iPad; "):
+	case l.match("iPad; "):
+		ua.Security = parseSecurity(l)
+		ua.OS = "iOS"
+		ua.Tablet = true
+	case l.match("iPhone; ") || l.match("iPod; "):
 		ua.Security = parseSecurity(l)
 		ua.OS = "iOS"
 		ua.Mobile = true

--- a/parse_test.go
+++ b/parse_test.go
@@ -212,13 +212,25 @@ func TestSafari(t *testing.T) {
 		t.Errorf("expected %+v, got %+v\n", want, got)
 	}
 
+	got = Parse(`Mozilla/5.0 (iPhone; CPU iPhone OS 6_1_4 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10B350 Safari/8536.25`)
+	want.Type = Browser
+	want.OS = "iOS"
+	want.Name = "Safari"
+	want.Version = mustParse("6.0.0")
+	want.Security = SecurityUnknown
+	want.Mobile = true
+	if !eqUA(want, got) {
+		t.Errorf("expected %+v, got %+v\n", want, got)
+	}
+
 	got = Parse(`Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B334b Safari/531.21.10`)
 	want.Type = Browser
 	want.OS = "iOS"
 	want.Name = "Safari"
 	want.Version = mustParse("4.0.4")
 	want.Security = SecurityStrong
-	want.Mobile = true
+	want.Mobile = false
+	want.Tablet = true
 	if !eqUA(want, got) {
 		t.Errorf("expected %+v, got %+v\n", want, got)
 	}

--- a/parse_test.go
+++ b/parse_test.go
@@ -122,6 +122,32 @@ func TestGecko(t *testing.T) {
 	if !eqUA(want, got) {
 		t.Errorf("expected:\n%+v\ngot:\n%+v\n", want, got)
 	}
+
+	// Silk on Kindle Fire: Tablet mode
+	got = Parse(`Mozilla/5.0 (Linux; Android 4.4.3; KFTHWI Build/KTU84M) AppleWebKit/537.36 (KHTML, like Gecko) Silk/44.1.54 like Chrome/44.0.2403.63 Safari/537.36`)
+	want.Type = Browser
+	want.OS = "Android"
+	want.Name = "Silk"
+	want.Version = mustParse("44.1.54")
+	want.Security = SecurityUnknown
+	want.Mobile = false
+	want.Tablet = true
+	if !eqUA(want, got) {
+		t.Errorf("expected:\n%+v\ngot:\n%+v\n", want, got)
+	}
+
+	// Silk on Kindle Fire: Mobile mode
+	got = Parse(`Mozilla/5.0 (Linux; U; Android 4.4.3; KFTHWI Build/KTU84M) AppleWebKit/537.36 (KHTML, like Gecko) Silk/44.1.54 like Chrome/44.0.2403.63 Mobile Safari/537.36`)
+	want.Type = Browser
+	want.OS = "Android"
+	want.Name = "Silk"
+	want.Version = mustParse("44.1.54")
+	want.Security = SecurityStrong
+	want.Mobile = true
+	want.Tablet = false
+	if !eqUA(want, got) {
+		t.Errorf("expected:\n%+v\ngot:\n%+v\n", want, got)
+	}
 }
 
 func TestChrome(t *testing.T) {


### PR DESCRIPTION
We've found your tool quite useful and would like to contribute some enhancements.

This patch recognizes the Silk browser on modern Kindle Fire tablets (but not 1st generation), as well as discriminating between mobile and tablet iOS devices.