### PR TITLE
support for curl and HTTPie

### DIFF
--- a/browser.go
+++ b/browser.go
@@ -3,25 +3,8 @@
 package useragent
 
 import (
-	"net/url"
-
 	"github.com/blang/semver"
 )
-
-// Keep them sorted
-var browsers = map[string]*url.URL{
-	"Chrome":    u("http://www.chromium.org/"),
-	"Dillo":     u("http://www.dillo.org/"),
-	"Edge":      u("https://www.microsoft.com/en-us/windows/microsoft-edge"),
-	"Firefox":   u("https://www.mozilla.org/en-US/firefox"),
-	"IceCat":    u("https://www.gnu.org/software/gnuzilla/"),
-	"Iceweasel": u("https://wiki.debian.org/Iceweasel"),
-	"NetSurf":   u("http://www.netsurf-browser.org/"),
-	"Opera":     u("http://www.opera.com/"),
-	"PhantomJS": u("http://phantomjs.org/"),
-	"Silk":      u("http://aws.amazon.com/documentation/silk/"),
-	"WebView":   u("http://developer.android.com/guide/webapps/webview.html"),
-}
 
 const (
 	OSAndroid = "Android"

--- a/crawler.go
+++ b/crawler.go
@@ -2,20 +2,6 @@
 
 package useragent
 
-import (
-	"net/url"
-)
-
-// Keep them sorted
-var crawlers = map[string]*url.URL{
-	"Google AdsBot":    u("https://support.google.com/webmasters/answer/1061943"),
-	"Google AdSense":   u("https://support.google.com/webmasters/answer/1061943"),
-	"Googlebot":        u("http://www.google.com/bot.html"),
-	"Googlebot Images": u("https://support.google.com/webmasters/answer/1061943"),
-	"Googlebot News":   u("https://support.google.com/news/publisher/answer/93977"),
-	"Googlebot Video":  u("https://support.google.com/webmasters/answer/1061943"),
-}
-
 func parseCrawler(l *lex) *UserAgent {
 	for _, f := range []parseFn{parseGooglebot, parseGooglebotSmartphone} {
 		if ua := f(newLex(l.s)); ua != nil {

--- a/generic.go
+++ b/generic.go
@@ -5,6 +5,7 @@ import "net/url"
 // Keep them sorted
 var libraries = map[string]*url.URL{
 	"curl":      u("https://curl.haxx.se/"),
+	"HTTPie":    u("https://github.com/jakubroztocil/httpie"),
 	"PhantomJS": u("http://phantomjs.org/"),
 }
 

--- a/generic.go
+++ b/generic.go
@@ -1,0 +1,60 @@
+package useragent
+
+import "net/url"
+
+// Keep them sorted
+var libraries = map[string]*url.URL{
+	"curl":      u("https://curl.haxx.se/"),
+	"PhantomJS": u("http://phantomjs.org/"),
+}
+
+// Keep them sorted
+var crawlers = map[string]*url.URL{
+	"Google AdsBot":    u("https://support.google.com/webmasters/answer/1061943"),
+	"Google AdSense":   u("https://support.google.com/webmasters/answer/1061943"),
+	"Googlebot":        u("http://www.google.com/bot.html"),
+	"Googlebot Images": u("https://support.google.com/webmasters/answer/1061943"),
+	"Googlebot News":   u("https://support.google.com/news/publisher/answer/93977"),
+	"Googlebot Video":  u("https://support.google.com/webmasters/answer/1061943"),
+}
+
+// Keep them sorted
+var browsers = map[string]*url.URL{
+	"Chrome":    u("http://www.chromium.org/"),
+	"Dillo":     u("http://www.dillo.org/"),
+	"Edge":      u("https://www.microsoft.com/en-us/windows/microsoft-edge"),
+	"Firefox":   u("https://www.mozilla.org/en-US/firefox"),
+	"IceCat":    u("https://www.gnu.org/software/gnuzilla/"),
+	"Iceweasel": u("https://wiki.debian.org/Iceweasel"),
+	"NetSurf":   u("http://www.netsurf-browser.org/"),
+	"Opera":     u("http://www.opera.com/"),
+	"Silk":      u("http://aws.amazon.com/documentation/silk/"),
+	"WebView":   u("http://developer.android.com/guide/webapps/webview.html"),
+}
+
+func parseGeneric(l *lex) *UserAgent {
+	ua := new()
+	if !parseNameVersion(l, ua) {
+		return nil
+	}
+
+	if url, ok := libraries[ua.Name]; ok {
+		ua.Type = Library
+		ua.URL = url
+		return ua
+	}
+
+	if url, ok := browsers[ua.Name]; ok {
+		ua.Type = Browser
+		ua.URL = url
+		return ua
+	}
+
+	if url, ok := crawlers[ua.Name]; ok {
+		ua.Type = Crawler
+		ua.URL = url
+		return ua
+	}
+
+	return nil
+}

--- a/parse.go
+++ b/parse.go
@@ -261,23 +261,3 @@ func parseNameVersion(l *lex, ua *UserAgent) bool {
 
 	return parseVersion(l, ua, " ")
 }
-
-func parseGeneric(l *lex) *UserAgent {
-	ua := new()
-	if !parseNameVersion(l, ua) {
-		return nil
-	}
-	if url, ok := browsers[ua.Name]; ok {
-		ua.Type = Browser
-		ua.URL = url
-		return ua
-	}
-
-	if url, ok := crawlers[ua.Name]; ok {
-		ua.Type = Crawler
-		ua.URL = url
-		return ua
-	}
-
-	return nil
-}

--- a/parse_test.go
+++ b/parse_test.go
@@ -438,6 +438,17 @@ func TestGeneric(t *testing.T) {
 	if !eqUA(want, got) {
 		t.Errorf("expected %+v, got %+v\n", want, got)
 	}
+
+	got = Parse(`HTTPie/0.9.8`)
+	want.Type = Library
+	want.OS = "unknown"
+	want.OSVersion = semver.Version{}
+	want.Name = "HTTPie"
+	want.Version = mustParse("0.9.8")
+	want.Security = SecurityUnknown
+	if !eqUA(want, got) {
+		t.Errorf("expected %+v, got %+v\n", want, got)
+	}
 }
 
 func TestPhantomJS(t *testing.T) {

--- a/parse_test.go
+++ b/parse_test.go
@@ -428,6 +428,16 @@ func TestGeneric(t *testing.T) {
 		t.Errorf("expected %+v, got %+v\n", want, got)
 	}
 
+	got = Parse(`curl/7.54.0`)
+	want.Type = Library
+	want.OS = "unknown"
+	want.OSVersion = semver.Version{}
+	want.Name = "curl"
+	want.Version = mustParse("7.54.0")
+	want.Security = SecurityUnknown
+	if !eqUA(want, got) {
+		t.Errorf("expected %+v, got %+v\n", want, got)
+	}
 }
 
 func TestPhantomJS(t *testing.T) {


### PR DESCRIPTION
The first user-agent I reached for to test xojoc/useragent in my service was curl. I'm also a fan of HTTPie.

I extracted a `generic.go` file that parallels `browser.go` and `crawler.go`, each with their own parser and supporting data. This allowed me to more easily see where to add additional libraries. If you'd rather I approach it another way, please let me know.